### PR TITLE
Fix for missing serial number

### DIFF
--- a/kandji_processor.php
+++ b/kandji_processor.php
@@ -23,6 +23,8 @@ class Kandji_processor extends Processor
         $parser = new CFPropertyList();
         $parser->parse($plist, CFPropertyList::FORMAT_XML);
         $mylist = $parser->toArray();
+
+        $mylist['serial_number'] = $this->serial_number;
         // Retrieve Kandji MR record (if existing)
         try {
             $model = Kandji_model::select()

--- a/scripts/kandji.py
+++ b/scripts/kandji.py
@@ -20,7 +20,6 @@ def get_local_kandji_prefs():
     return result
 
 def get_users_info():
-
     # Get all users info as plist
     cmd = ['/usr/bin/dscl', '-plist', '.', '-readall', '/Users']
     proc = subprocess.Popen(cmd, shell=False, bufsize=-1,


### PR DESCRIPTION
Fixes an issue where the Processor did not pass the serial number of the reporting device on, so queries to Kandji against the device failed.